### PR TITLE
P4P Update

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -2,6 +2,9 @@
 # RELEASE_NOTES
 # extensions
 #
+R1.5.0  2025-09-17  Jeremy Lorelli
+    Update P4P to R4.1.7-1.1.0
+
 R1.4.2  2025-05-05  Jeremy Lorelli
     Downgrade p4p to R4.1.6-1.0.0. Needs additional testing with Python 3.10
 

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -20,4 +20,4 @@ LABCA			= $(EPICS_EXTENSIONS)/labca/R3.8.1-0.3.0
 PARSECASW		= $(EPICS_EXTENSIONS)/parsecasw/R1.0.3.0-0.1.0
 PROBE			= $(EPICS_EXTENSIONS)/probe/R1.1.8.0-0.2.1
 IOCLOGMSGSERVER	= $(EPICS_EXTENSIONS)/iocLogMsgServer/R1.11.0
-P4P                     = $(EPICS_EXTENSIONS)/p4p/R4.1.6-1.0.0
+P4P                     = $(EPICS_EXTENSIONS)/p4p/R4.1.7-1.1.0


### PR DESCRIPTION
* Update P4P to latest deployed version

Next version number will be R1.5.0 due to the potentially significant upgrade of the pva gateway.